### PR TITLE
🐛 Fix: 탭 버튼 폰트 두께 수정

### DIFF
--- a/src/components/post/TabButtonBox.jsx
+++ b/src/components/post/TabButtonBox.jsx
@@ -11,7 +11,7 @@ const tabs = [
 
 // 버튼 스타일 정의
 const tabButton = cva(
-  'flex items-center justify-center font-16-medium transition-all duration-200 rounded-md h-10 w-[118px] md:w-[122px]',
+  'flex items-center justify-center font-16-bold transition-all duration-200 rounded-md h-10 w-[118px] md:w-[122px]',
   {
     variants: {
       active: {


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈와 동일하게 작성해 주세요. ex) ✨ Feat: 로그인 페이지 UI 구현 -->

## 🔗 이슈 번호 #65
- close #65

## ✨ 작업한 내용
탭 버튼 폰트 두께가 시안과 달라 수정했습니다
