### PR TITLE
🐛 Bug: 토스트 메세지 전역관리로 변경 및 롤링페이퍼 리스트 데이터 없을 때 에러처리 로직 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
+import ToastContainer from '@/components/rolling-paper-list/toast/ToastContainer';
 import ErrorProvider from '@/context/error/ErrorProvider';
+import ToastProvider from '@/context/toast/ToastProvider';
 import useKakaoInit from '@/hooks/useKakaoInit';
 import Router from '@/router/Router';
 
@@ -6,7 +8,10 @@ const App = () => {
   useKakaoInit();
   return (
     <ErrorProvider>
-      <Router />
+      <ToastProvider>
+        <Router />
+        <ToastContainer />
+      </ToastProvider>
     </ErrorProvider>
   );
 };

--- a/src/components/common/layout/PostLayout.jsx
+++ b/src/components/common/layout/PostLayout.jsx
@@ -1,13 +1,17 @@
 import { Outlet, useParams } from 'react-router';
+import Error from '@/components/common/Error';
 import Footer from '@/components/common/Footer';
 import Header from '@/components/common/Header';
 import ListBackground from '@/components/rolling-paper-list/ListBackground';
 import SubHeader from '@/components/rolling-paper-list/sub-header/SubHeader';
+import useError from '@/hooks/useError';
 import useRecipientData from '@/hooks/useRecipientData.jsx';
 
 const PostLayout = () => {
   const { id } = useParams();
+  const { error } = useError();
   const { recipientData } = useRecipientData(id);
+
   return (
     <>
       <Header />
@@ -17,7 +21,7 @@ const PostLayout = () => {
         backgroundColor={recipientData?.backgroundColor ?? 'beige'}
         className="wrapper-px min-h-[calc(100dvh-297px)] w-full">
         <div className="content pt-15 pb-25">
-          <Outlet />
+          {error ? <Error /> : <Outlet />}
         </div>
       </ListBackground>
       <Footer />

--- a/src/components/rolling-paper-list/MessageList.jsx
+++ b/src/components/rolling-paper-list/MessageList.jsx
@@ -1,12 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import Error from '@/components/common/Error';
 import Modal from '@/components/common/modal/Modal';
 import AddMessageCardButton from '@/components/rolling-paper-list/message-card/AddMessageCardButton';
 import MessageCard from '@/components/rolling-paper-list/message-card/MessageCard';
 import MessageCardSkeleton from '@/components/rolling-paper-list/message-card/MessageCardSkeleton';
 import ToastContainer from '@/components/rolling-paper-list/toast/ToastContainer';
 import { MESSAGE_LIST_SKELETON_ARRAY } from '@/constants/rollingPaperList';
-import useError from '@/hooks/useError';
 import useMessages from '@/hooks/useMessages';
 import useToast from '@/hooks/useToast';
 
@@ -18,8 +16,7 @@ import useToast from '@/hooks/useToast';
  * @returns {JSX.Element}
  */
 const MessageList = ({ recipientId, isEditPage = false }) => {
-  const { toasts, showToast, removeToast } = useToast();
-  const { error } = useError();
+  const { showToast } = useToast();
   const {
     messages,
     loading,
@@ -106,10 +103,6 @@ const MessageList = ({ recipientId, isEditPage = false }) => {
     );
   }
 
-  if (error) {
-    return <Error />;
-  }
-
   return (
     <>
       <div className="card-grid-style">
@@ -156,8 +149,6 @@ const MessageList = ({ recipientId, isEditPage = false }) => {
           font={selectedMessage.font}
         />
       )}
-
-      <ToastContainer toasts={toasts} removeToast={removeToast} />
     </>
   );
 };

--- a/src/components/rolling-paper-list/MessageList.jsx
+++ b/src/components/rolling-paper-list/MessageList.jsx
@@ -3,7 +3,6 @@ import Modal from '@/components/common/modal/Modal';
 import AddMessageCardButton from '@/components/rolling-paper-list/message-card/AddMessageCardButton';
 import MessageCard from '@/components/rolling-paper-list/message-card/MessageCard';
 import MessageCardSkeleton from '@/components/rolling-paper-list/message-card/MessageCardSkeleton';
-import ToastContainer from '@/components/rolling-paper-list/toast/ToastContainer';
 import { MESSAGE_LIST_SKELETON_ARRAY } from '@/constants/rollingPaperList';
 import useMessages from '@/hooks/useMessages';
 import useToast from '@/hooks/useToast';
@@ -84,8 +83,7 @@ const MessageList = ({ recipientId, isEditPage = false }) => {
       } else {
         showToast('메시지 삭제에 실패했습니다. 다시 시도해주세요.', 'error');
       }
-    } catch (err) {
-      console.error(err);
+    } catch {
       showToast(
         '삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
         'error'

--- a/src/components/rolling-paper-list/sub-header/SubHeader.jsx
+++ b/src/components/rolling-paper-list/sub-header/SubHeader.jsx
@@ -3,7 +3,6 @@ import ShareDropdown from '@/components/common/dropbox/ShareDropdown';
 import ProfileGroup from '@/components/common/profile-image/ProfileGroup';
 import EmojiPickerButton from '@/components/rolling-paper-list/sub-header/EmojiPickerButton';
 import EmojiSummary from '@/components/rolling-paper-list/sub-header/EmojiSummary';
-import ToastContainer from '@/components/rolling-paper-list/toast/ToastContainer';
 import {
   KAKAO_TEMPLATE_ID,
   SHARE_OPTION_KAKAO,
@@ -35,7 +34,7 @@ const SubHeader = ({ recipientId }) => {
     loading: reactionsLoading,
     pageSize,
   } = useReactions(recipientId);
-  const { toasts, showToast, removeToast } = useToast();
+  const { showToast } = useToast();
 
   if (error) {
     return null;
@@ -188,7 +187,6 @@ const SubHeader = ({ recipientId }) => {
           </div>
         </div>
       </div>
-      <ToastContainer toasts={toasts} removeToast={removeToast} />
     </>
   );
 };

--- a/src/components/rolling-paper-list/toast/ToastContainer.jsx
+++ b/src/components/rolling-paper-list/toast/ToastContainer.jsx
@@ -1,16 +1,20 @@
 import Toast from '@/components/rolling-paper-list/toast/Toast';
+import useToast from '@/hooks/useToast';
 
 /**
- * Toast 메시지 목록을 관리하고 화면에 표시하는 컨테이너 컴포넌트입니다.
- * 모든 토스트 메시지를 화면 하단 중앙에 스택 형태로 배치합니다.
+ * 전역 Toast 메시지 목록을 구독하고 화면에 표시하는 컨테이너 컴포넌트입니다.
+ * useToast 훅을 통해 활성화된 토스트 목록을 가져와 화면 하단 중앙에 스택 형태로 배치합니다.
  *
  * @component
- * @param {object} props - 컴포넌트의 props
- * @param {Array<Object>} props.toasts - 현재 활성화된 토스트 메시지 객체 목록
- * @param {function(string | number): void} props.removeToast - 토스트 ID를 받아 해당 토스트를 목록에서 제거하는 함수
  * @returns {JSX.Element} 토스트 메시지 컨테이너
  */
-const ToastContainer = ({ toasts, removeToast }) => {
+const ToastContainer = () => {
+  const { toasts, removeToast } = useToast();
+
+  if (toasts.length === 0) {
+    return null;
+  }
+
   return (
     <div className="fixed bottom-[88px] left-1/2 z-[2000] flex -translate-x-1/2 flex-col items-center gap-2 sm:bottom-[70px]">
       {toasts.map((toast) => {

--- a/src/context/toast/ToastProvider.jsx
+++ b/src/context/toast/ToastProvider.jsx
@@ -1,0 +1,42 @@
+import { useCallback, useRef, useState } from 'react';
+import { ToastContext } from '@/context/toast/toastContext';
+
+/**
+ * 전역 토스트 메시지 목록을 관리하고 하위 컴포넌트에 Context를 통해 제공하는 프로바이더입니다.
+ * 토스트 메시지의 생성(showToast)과 제거(removeToast) 로직을 캡슐화하여 제공합니다.
+ * @component
+ * @param {object} props - 컴포넌트의 props
+ * @param {React.ReactNode} props.children - Context의 상태를 공유할 하위 React 요소들
+ * @returns {JSX.Element} Toast Context Provider 컴포넌트
+ */
+const ToastProvider = ({ children }) => {
+  const [toasts, setToasts] = useState([]);
+  const toastId = useRef(0);
+
+  /**
+   * 새로운 토스트 메시지를 목록에 추가합니다.
+   * @param {string} message - 사용자에게 표시할 메시지 내용
+   * @param {'success' | 'error'} [type='success'] - 토스트 메시지의 유형
+   */
+  const showToast = useCallback((message, type = 'success') => {
+    toastId.current += 1;
+    const id = toastId.current;
+    setToasts((prev) => [...prev, { id, message, type }]);
+  }, []);
+
+  /**
+   * 특정 ID를 가진 토스트 메시지를 목록에서 제거합니다.
+   * @param {number} id - 제거할 토스트의 고유 ID
+   */
+  const removeToast = useCallback((id) => {
+    setToasts((prev) => prev.filter((toast) => toast.id !== id));
+  }, []);
+
+  return (
+    <ToastContext value={{ toasts, showToast, removeToast }}>
+      {children}
+    </ToastContext>
+  );
+};
+
+export default ToastProvider;

--- a/src/context/toast/toastContext.js
+++ b/src/context/toast/toastContext.js
@@ -1,0 +1,14 @@
+import { createContext } from 'react';
+
+/**
+ * 토스트 메시지 관련 상태와 제어 함수를 제공하는 Context
+ * @typedef {Object} ToastContextType
+ * @property {Array<{id: number, message: string, type: 'success' | 'error'}>} toasts - 현재 활성화된 토스트 메시지 목록
+ * @property {(message: string, type?: 'success' | 'error') => void} showToast - 새로운 토스트를 추가하는 함수
+ * @property {(id: number) => void} removeToast - 특정 ID의 토스트를 제거하는 함수
+ */
+export const ToastContext = createContext({
+  toasts: [],
+  showToast: () => {},
+  removeToast: () => {},
+});

--- a/src/hooks/useToast.jsx
+++ b/src/hooks/useToast.jsx
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState } from 'react';
+import { useContext } from 'react';
+import { ToastContext } from '@/context/toast/toastContext';
 
 /**
  * 토스트 메시지 목록을 생성, 표시 및 관리하는 커스텀 훅입니다.
@@ -9,29 +10,11 @@ import { useCallback, useRef, useState } from 'react';
  * }} - 현재 토스트 목록과 제어 함수를 반환합니다.
  */
 const useToast = () => {
-  const [toasts, setToasts] = useState([]);
-  const toastId = useRef(0);
-
-  /**
-   * 새로운 토스트 메시지를 목록에 추가합니다.
-   * @param {string} message - 사용자에게 표시할 메시지 내용
-   * @param {'success' | 'error'} [type='success'] - 토스트 메시지의 유형
-   */
-  const showToast = useCallback((message, type = 'success') => {
-    toastId.current += 1;
-    const id = toastId.current;
-    setToasts((prev) => [...prev, { id, message, type }]);
-  }, []);
-
-  /**
-   * 특정 ID를 가진 토스트 메시지를 목록에서 제거합니다.
-   * @param {number} id - 제거할 토스트의 고유 ID
-   */
-  const removeToast = useCallback((id) => {
-    setToasts((prev) => prev.filter((toast) => toast.id !== id));
-  }, []);
-
-  return { toasts, showToast, removeToast };
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
 };
 
 export default useToast;

--- a/src/pages/PostEdit.jsx
+++ b/src/pages/PostEdit.jsx
@@ -30,7 +30,6 @@ const PostEdit = () => {
       {/* 상단 영역 (PC에서만 보여짐) */}
       <div className="mb-4 flex items-center justify-between">
         <ToggleSwitch to={`/post/${id}`} isEditMode />
-
         {/* PC용 삭제 버튼 (고정 X, 상단 오른쪽 위치) */}
         <Button
           size={40}

--- a/src/pages/PostEdit.jsx
+++ b/src/pages/PostEdit.jsx
@@ -2,13 +2,12 @@ import { useNavigate, useParams } from 'react-router';
 import { deleteRecipient } from '@/apis/recipients';
 import Button from '@/components/common/button/Button';
 import MessageList from '@/components/rolling-paper-list/MessageList';
-import ToastContainer from '@/components/rolling-paper-list/toast/ToastContainer';
 import ToggleSwitch from '@/components/rolling-paper-list/ToggleSwitch';
 import useToast from '@/hooks/useToast';
 
 const PostEdit = () => {
   const { id } = useParams();
-  const { toasts, showToast, removeToast } = useToast();
+  const { showToast } = useToast();
   const navigate = useNavigate();
 
   const handleDeleteRollingPaper = async () => {
@@ -20,8 +19,9 @@ const PostEdit = () => {
       await deleteRecipient(id);
       showToast('롤링페이퍼가 삭제되었습니다.', 'success');
       navigate('/');
-    } catch {
-      showToast('삭제에 실패했습니다. 다시 시도해주세요.');
+    } catch (error) {
+      console.error('롤링페이퍼 삭제 실패:', error);
+      showToast('삭제에 실패했습니다. 다시 시도해주세요.', 'error');
     }
   };
 
@@ -52,7 +52,6 @@ const PostEdit = () => {
           삭제하기
         </Button>
       </div>
-      <ToastContainer toasts={toasts} removeToast={removeToast} />
     </>
   );
 };

--- a/src/pages/PostEdit.jsx
+++ b/src/pages/PostEdit.jsx
@@ -19,8 +19,7 @@ const PostEdit = () => {
       await deleteRecipient(id);
       showToast('롤링페이퍼가 삭제되었습니다.', 'success');
       navigate('/');
-    } catch (error) {
-      console.error('롤링페이퍼 삭제 실패:', error);
+    } catch {
       showToast('삭제에 실패했습니다. 다시 시도해주세요.', 'error');
     }
   };
@@ -38,10 +37,8 @@ const PostEdit = () => {
           삭제하기
         </Button>
       </div>
-
       {/* 메시지 리스트 */}
       <MessageList recipientId={id} isEditPage />
-
       {/* 모바일 및 태블릿 전용 하단 고정 버튼 */}
       <div className="fixed bottom-6 left-1/2 z-50 w-[calc(100%-40px)] -translate-x-1/2 sm:w-[720px] sm:px-4 lg:hidden">
         <Button


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈와 동일하게 작성해 주세요. ex) ✨ Feat: 로그인 페이지 UI 구현 -->

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #117

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->

- 중복된 주석 삭제하였습니다.
- MessageList에서 처리하던 에러 처리를 PostLayout로 이동하였습니다.
- 토스트 상태를 전역적으로 관리할 수 있도록 컨택스트 생성하였습니다.

## 💁 Review Point

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

- 수정사항 있으시면 말씀해주세요.

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->

- 토스트를 전역으로 관리하도록 수정하여서 `<ToastContainer />`를 App.jsx에 추가해두었습니다.
- 토스트를 보여줘야 하는 페이지에 `<ToastContainer />`를 매번 추가하지 않아도 됩니다!
