### PR TITLE
✨ Feat: 롤링페이퍼 리스트 페이지네이션 기능 추가

### DIFF
--- a/src/apis/recipients.js
+++ b/src/apis/recipients.js
@@ -52,14 +52,25 @@ export const getRecipientData = async (recipientId, signal) => {
   };
 };
 
+/**
+ * 롤링페이퍼 리스트 데이터를 가져오는 API
+ */
 export const getRollingPaperData = async (
-  { limit = LIST_LIMIT, sort },
+  { limit = LIST_LIMIT, sort, url },
   signal
 ) => {
-  const res = await teamApi.get(
-    `recipients/?limit=${limit}&offset=0${sort && `&sort=${sort}`}`,
-    { signal }
-  );
+  let res;
+
+  if (url) {
+    const axios = (await import('axios')).default;
+    res = await axios.get(url, { signal });
+  } else {
+    res = await teamApi.get(
+      `recipients/?limit=${limit}&offset=0${sort ? `&sort=${sort}` : ''}`,
+      { signal }
+    );
+  }
+
   return res.data;
 };
 

--- a/src/apis/recipients.js
+++ b/src/apis/recipients.js
@@ -54,22 +54,21 @@ export const getRecipientData = async (recipientId, signal) => {
 
 /**
  * 롤링페이퍼 리스트 데이터를 가져오는 API
+ * @param {Object} params - 요청 파라미터
+ * @param {number} [params.limit=LIST_LIMIT] - 요청할 데이터 개수
+ * @param {string} [params.sort] - 정렬 기준 ('like' | undefined)
+ * @param {string} [params.url] - 페이지네이션용 전체 URL
+ * @param {AbortSignal} [signal] - 요청 취소용 AbortSignal
+ * @returns {Promise<Object>} 롤링페이퍼 리스트 데이터
  */
 export const getRollingPaperData = async (
   { limit = LIST_LIMIT, sort, url },
   signal
 ) => {
-  let res;
-
-  if (url) {
-    res = await teamApi.get(url, { signal });
-  } else {
-    res = await teamApi.get(
-      `recipients/?limit=${limit}&offset=0${sort ? `&sort=${sort}` : ''}`,
-      { signal }
-    );
-  }
-
+  const endpoint = url
+    ? url
+    : `recipients/?limit=${limit}&offset=0${sort ? `&sort=${sort}` : ''}`;
+  const res = await teamApi.get(endpoint, { signal });
   return res.data;
 };
 

--- a/src/apis/recipients.js
+++ b/src/apis/recipients.js
@@ -62,8 +62,7 @@ export const getRollingPaperData = async (
   let res;
 
   if (url) {
-    const axios = (await import('axios')).default;
-    res = await axios.get(url, { signal });
+    res = await teamApi.get(url, { signal });
   } else {
     res = await teamApi.get(
       `recipients/?limit=${limit}&offset=0${sort ? `&sort=${sort}` : ''}`,

--- a/src/components/papers/LikeSortedRollingPaper.jsx
+++ b/src/components/papers/LikeSortedRollingPaper.jsx
@@ -1,44 +1,15 @@
-import { useState, useEffect } from 'react';
 import RollingPaperList from '@/components/papers/RollingPaperList';
-import useError from '@/hooks/useError';
 import useRollingPaperData from '@/hooks/useRollingPaperData';
 
 const LikeSortedRollingPaper = () => {
-  const { error, setError } = useError();
-  const { fetchRollingPaperData } = useRollingPaperData('like');
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(false);
-
-  const fetchData = async (url) => {
-    setLoading(true);
-    try {
-      const result = await fetchRollingPaperData(url);
-      setData(result);
-    } catch (err) {
-      console.error(err);
-      setError(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchData();
-  }, []);
-
-  const handlePageChange = (url) => {
-    fetchData(url);
-  };
-
-  if (error) {
-    return <div className="text-error">에러가 발생했어요!</div>;
-  }
+  const { data, loading, goNext, goPrev } = useRollingPaperData('like');
 
   return (
     <RollingPaperList
       data={data}
       loading={loading}
-      onPageChange={handlePageChange}
+      onNext={goNext}
+      onPrev={goPrev}
     />
   );
 };

--- a/src/components/papers/LikeSortedRollingPaper.jsx
+++ b/src/components/papers/LikeSortedRollingPaper.jsx
@@ -1,17 +1,39 @@
+import { useState, useEffect } from 'react';
 import RollingPaperList from '@/components/papers/RollingPaperList';
 import useError from '@/hooks/useError';
 import useRollingPaperData from '@/hooks/useRollingPaperData';
 
 const LikeSortedRollingPaper = () => {
   const { error } = useError();
-  const { data, loading } = useRollingPaperData('like');
+  const { fetchRollingPaperData } = useRollingPaperData('like');
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const fetchData = async (url) => {
+    setLoading(true);
+    const result = await fetchRollingPaperData(url);
+    setData(result);
+    setLoading(false);
+  };
 
-  // 이 부분도 나중에 수정해보면 좋을 것 같습니다!
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const handlePageChange = (url) => {
+    fetchData(url);
+  };
+
   if (error) {
     return <div className="text-error">에러가 발생했어요!</div>;
   }
 
-  return <RollingPaperList data={data} loading={loading} />;
+  return (
+    <RollingPaperList
+      data={data}
+      loading={loading}
+      onPageChange={handlePageChange}
+    />
+  );
 };
 
 export default LikeSortedRollingPaper;

--- a/src/components/papers/LikeSortedRollingPaper.jsx
+++ b/src/components/papers/LikeSortedRollingPaper.jsx
@@ -4,15 +4,22 @@ import useError from '@/hooks/useError';
 import useRollingPaperData from '@/hooks/useRollingPaperData';
 
 const LikeSortedRollingPaper = () => {
-  const { error } = useError();
+  const { error, setError } = useError();
   const { fetchRollingPaperData } = useRollingPaperData('like');
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
+
   const fetchData = async (url) => {
     setLoading(true);
-    const result = await fetchRollingPaperData(url);
-    setData(result);
-    setLoading(false);
+    try {
+      const result = await fetchRollingPaperData(url);
+      setData(result);
+    } catch (err) {
+      console.error(err);
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => {

--- a/src/components/papers/RecentSortedRollingPaper.jsx
+++ b/src/components/papers/RecentSortedRollingPaper.jsx
@@ -4,15 +4,22 @@ import useError from '@/hooks/useError';
 import useRollingPaperData from '@/hooks/useRollingPaperData';
 
 const RecentSortedRollingPaper = () => {
-  const { error } = useError();
+  const { error, setError } = useError();
   const { fetchRollingPaperData } = useRollingPaperData();
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
+
   const fetchData = async (url) => {
     setLoading(true);
-    const result = await fetchRollingPaperData(url);
-    setData(result);
-    setLoading(false);
+    try {
+      const result = await fetchRollingPaperData(url);
+      setData(result);
+    } catch (err) {
+      console.error(err);
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => {

--- a/src/components/papers/RecentSortedRollingPaper.jsx
+++ b/src/components/papers/RecentSortedRollingPaper.jsx
@@ -1,44 +1,15 @@
-import { useState, useEffect } from 'react';
 import RollingPaperList from '@/components/papers/RollingPaperList';
-import useError from '@/hooks/useError';
 import useRollingPaperData from '@/hooks/useRollingPaperData';
 
 const RecentSortedRollingPaper = () => {
-  const { error, setError } = useError();
-  const { fetchRollingPaperData } = useRollingPaperData();
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(false);
-
-  const fetchData = async (url) => {
-    setLoading(true);
-    try {
-      const result = await fetchRollingPaperData(url);
-      setData(result);
-    } catch (err) {
-      console.error(err);
-      setError(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchData();
-  }, []);
-
-  const handlePageChange = (url) => {
-    fetchData(url);
-  };
-
-  if (error) {
-    return <div className="text-error">에러가 발생했어요!</div>;
-  }
+  const { data, loading, goNext, goPrev } = useRollingPaperData();
 
   return (
     <RollingPaperList
       data={data}
       loading={loading}
-      onPageChange={handlePageChange}
+      onNext={goNext}
+      onPrev={goPrev}
     />
   );
 };

--- a/src/components/papers/RecentSortedRollingPaper.jsx
+++ b/src/components/papers/RecentSortedRollingPaper.jsx
@@ -1,17 +1,39 @@
+import { useState, useEffect } from 'react';
 import RollingPaperList from '@/components/papers/RollingPaperList';
 import useError from '@/hooks/useError';
 import useRollingPaperData from '@/hooks/useRollingPaperData';
 
 const RecentSortedRollingPaper = () => {
   const { error } = useError();
-  const { data, loading } = useRollingPaperData();
+  const { fetchRollingPaperData } = useRollingPaperData();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const fetchData = async (url) => {
+    setLoading(true);
+    const result = await fetchRollingPaperData(url);
+    setData(result);
+    setLoading(false);
+  };
 
-  // 이 부분도 나중에 수정해보면 좋을 것 같습니다
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const handlePageChange = (url) => {
+    fetchData(url);
+  };
+
   if (error) {
     return <div className="text-error">에러가 발생했어요!</div>;
   }
 
-  return <RollingPaperList data={data} loading={loading} />;
+  return (
+    <RollingPaperList
+      data={data}
+      loading={loading}
+      onPageChange={handlePageChange}
+    />
+  );
 };
 
 export default RecentSortedRollingPaper;

--- a/src/components/papers/RollingPaperList.jsx
+++ b/src/components/papers/RollingPaperList.jsx
@@ -3,7 +3,7 @@ import RollingPaperCard from '@/components/papers/rolling-paper-card/RollingPape
 import RollingPaperCardSkeleton from '@/components/papers/rolling-paper-card/RollingPaperCardSkeleton';
 import { LIST_LIMIT_ARRAY } from '@/constants/list';
 
-const RollingPaperList = ({ data, loading }) => {
+const RollingPaperList = ({ data, loading, onPageChange }) => {
   if (loading || !data) {
     return (
       <div className="rolling-paper-list-style">
@@ -16,7 +16,12 @@ const RollingPaperList = ({ data, loading }) => {
 
   return (
     <div className="rolling-paper-list-style relative">
-      {data.previous && <ArrowButton position="left" />}
+      {data.previous && (
+        <ArrowButton
+          position="left"
+          onClick={() => onPageChange(data.previous)}
+        />
+      )}
       {data.results.length > 0 ? (
         data.results.map((card) => {
           return (
@@ -38,7 +43,9 @@ const RollingPaperList = ({ data, loading }) => {
         </div>
       )}
 
-      {data.next && <ArrowButton position="right" />}
+      {data.next && (
+        <ArrowButton position="right" onClick={() => onPageChange(data.next)} />
+      )}
     </div>
   );
 };

--- a/src/components/papers/RollingPaperList.jsx
+++ b/src/components/papers/RollingPaperList.jsx
@@ -3,7 +3,7 @@ import RollingPaperCard from '@/components/papers/rolling-paper-card/RollingPape
 import RollingPaperCardSkeleton from '@/components/papers/rolling-paper-card/RollingPaperCardSkeleton';
 import { LIST_LIMIT_ARRAY } from '@/constants/list';
 
-const RollingPaperList = ({ data, loading, onPageChange }) => {
+const RollingPaperList = ({ data, loading, onNext, onPrev }) => {
   if (loading || !data) {
     return (
       <div className="rolling-paper-list-style">
@@ -16,12 +16,10 @@ const RollingPaperList = ({ data, loading, onPageChange }) => {
 
   return (
     <div className="rolling-paper-list-style relative">
-      {data.previous && (
-        <ArrowButton
-          position="left"
-          onClick={() => onPageChange(data.previous)}
-        />
-      )}
+      {/* 왼쪽 화살표 */}
+      {data.previous && <ArrowButton position="left" onClick={onPrev} />}
+
+      {/* 카드 리스트 */}
       {data.results.length > 0 ? (
         data.results.map((card) => {
           return (
@@ -43,9 +41,8 @@ const RollingPaperList = ({ data, loading, onPageChange }) => {
         </div>
       )}
 
-      {data.next && (
-        <ArrowButton position="right" onClick={() => onPageChange(data.next)} />
-      )}
+      {/* 오른쪽 화살표 */}
+      {data.next && <ArrowButton position="right" onClick={onNext} />}
     </div>
   );
 };

--- a/src/hooks/useRollingPaperData.js
+++ b/src/hooks/useRollingPaperData.js
@@ -8,9 +8,26 @@ const useRollingPaperData = (sort) => {
       { limit: LIST_LIMIT, sort: sort === 'like' ? 'like' : null },
       signal
     );
+
   const { data, loading } = useDataFetch(fetcher, [sort]);
 
-  return { data, loading };
+  const fetchRollingPaperData = async (url) => {
+    if (!url) {
+      return await getRollingPaperData({
+        limit: LIST_LIMIT,
+        sort: sort === 'like' ? 'like' : null,
+      });
+    }
+
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error('데이터를 불러오는 중 오류가 발생했습니다.');
+    }
+    const json = await res.json();
+    return json;
+  };
+
+  return { data, loading, fetchRollingPaperData };
 };
 
 export default useRollingPaperData;

--- a/src/hooks/useRollingPaperData.js
+++ b/src/hooks/useRollingPaperData.js
@@ -1,22 +1,57 @@
+import { useCallback } from 'react';
 import { getRollingPaperData } from '@/apis/recipients';
 import { LIST_LIMIT } from '@/constants/list';
+import useDataFetch from '@/hooks/useDataFetch';
+import useError from '@/hooks/useError';
 
 /**
  * 롤링페이퍼 데이터를 가져오는 커스텀 훅
  * - 정렬 기준(sort)과 페이지네이션 URL에 따라 데이터를 가져옵니다.
- * - 컴포넌트에서 data/loading/error 상태를 직접 관리할 때 사용합니다.
+ * - 다음/이전 페이지 이동 함수를 함께 제공합니다.
+ *
  * @param {string} [sort] - 정렬 기준 ('like' 또는 undefined)
- * @returns {{ fetchRollingPaperData: (url?: string) => Promise<any> }}
+ * @returns {{
+ *   data: Object | null,
+ *   loading: boolean,
+ *   goNext: () => void,
+ *   goPrev: () => void
+ * }}
  */
 const useRollingPaperData = (sort) => {
-  const fetchRollingPaperData = async (url) =>
-    getRollingPaperData({
-      limit: LIST_LIMIT,
-      sort: sort === 'like' ? 'like' : null,
-      url,
-    });
+  const { setError } = useError();
 
-  return { fetchRollingPaperData };
+  const fetcher = async (signal) =>
+    getRollingPaperData(
+      { limit: LIST_LIMIT, sort: sort === 'like' ? 'like' : null },
+      signal
+    );
+
+  const { data, setData, loading } = useDataFetch(fetcher, [sort]);
+
+  const fetchPage = useCallback(
+    async (url) => {
+      if (!url) {
+        return;
+      }
+      try {
+        const result = await getRollingPaperData({ url });
+        setData(result);
+      } catch (err) {
+        setError({
+          status: err.response?.status || 500,
+          message:
+            err.response?.data?.message ||
+            '페이지 데이터를 불러오는 데 실패했습니다.',
+        });
+      }
+    },
+    [setData, setError]
+  );
+
+  const goNext = () => fetchPage(data?.next);
+  const goPrev = () => fetchPage(data?.previous);
+
+  return { data, loading, goNext, goPrev };
 };
 
 export default useRollingPaperData;

--- a/src/hooks/useRollingPaperData.js
+++ b/src/hooks/useRollingPaperData.js
@@ -1,33 +1,22 @@
 import { getRollingPaperData } from '@/apis/recipients';
 import { LIST_LIMIT } from '@/constants/list';
-import useDataFetch from '@/hooks/useDataFetch';
 
+/**
+ * 롤링페이퍼 데이터를 가져오는 커스텀 훅
+ * - 정렬 기준(sort)과 페이지네이션 URL에 따라 데이터를 가져옵니다.
+ * - 컴포넌트에서 data/loading/error 상태를 직접 관리할 때 사용합니다.
+ * @param {string} [sort] - 정렬 기준 ('like' 또는 undefined)
+ * @returns {{ fetchRollingPaperData: (url?: string) => Promise<any> }}
+ */
 const useRollingPaperData = (sort) => {
-  const fetcher = async (signal) =>
-    getRollingPaperData(
-      { limit: LIST_LIMIT, sort: sort === 'like' ? 'like' : null },
-      signal
-    );
+  const fetchRollingPaperData = async (url) =>
+    getRollingPaperData({
+      limit: LIST_LIMIT,
+      sort: sort === 'like' ? 'like' : null,
+      url,
+    });
 
-  const { data, loading } = useDataFetch(fetcher, [sort]);
-
-  const fetchRollingPaperData = async (url) => {
-    if (!url) {
-      return await getRollingPaperData({
-        limit: LIST_LIMIT,
-        sort: sort === 'like' ? 'like' : null,
-      });
-    }
-
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error('데이터를 불러오는 중 오류가 발생했습니다.');
-    }
-    const json = await res.json();
-    return json;
-  };
-
-  return { data, loading, fetchRollingPaperData };
+  return { fetchRollingPaperData };
 };
 
 export default useRollingPaperData;


### PR DESCRIPTION
## 🔗 이슈 번호

- #130 

## ✨ 작업한 내용

- 롤링페이퍼 리스트에서 next/previous 페이지 이동 기능 추가
- ArrowButton 클릭 시 상위 컴포넌트에서 데이터 재요청
- useRollingPaperData 훅 및 recipients API 수정으로 페이지네이션 URL 지원
