### PR TITLE
[🐛 Bug] 텍스트 에디터 내부에서 글꼴 적용후 noto-sans로 강제로 바뀌는 버그

### DIFF
--- a/src/pages/PostMessage.jsx
+++ b/src/pages/PostMessage.jsx
@@ -28,7 +28,24 @@ const PostMessage = () => {
   const [profileImageURL, setProfileImageURL] = useState('');
   const [selectedFont, setSelectedFont] = useState('Noto Sans');
 
-  const handleFontChange = () => {
+  // TextEditor에서 폰트 변경 시 호출 (fontKey를 직접 받음)
+  const handleEditorFontChange = (fontKey) => {
+    if (!fontKey) {
+      return;
+    }
+
+    // 선택된 폰트 상태 업데이트
+    setSelectedFont(fontKey);
+
+    // 외부 드롭다운도 동기화
+    const displayName = FONT_DISPLAY_NAMES[fontKey];
+    if (displayName && fontRef.current?.setValue) {
+      fontRef.current.setValue(displayName);
+    }
+  };
+
+  // 외부 Dropdown에서 폰트 변경 시 호출
+  const handleDropdownFontChange = () => {
     const selectedDisplayName = fontRef.current?.getValue();
     if (!selectedDisplayName) {
       return;
@@ -169,7 +186,7 @@ const PostMessage = () => {
           value={content}
           onChange={setContent}
           font={selectedFont}
-          onFontChange={handleFontChange}
+          onFontChange={handleEditorFontChange}
         />
       </div>
       <div className="flex flex-col gap-4">
@@ -178,7 +195,7 @@ const PostMessage = () => {
           ref={fontRef}
           items={FONT_ITEMS}
           defaultValue="Noto Sans"
-          onSelect={handleFontChange}
+          onSelect={handleDropdownFontChange}
         />
       </div>
       <FloatingButtonContainer>


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈와 동일하게 작성해 주세요. ex) ✨ Feat: 로그인 페이지 UI 구현 -->

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #156 

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
- 텍스트 에디터 내부에서 글꼴 적용후 noto-sans로 강제로 바뀌는 버그를 해결하였습니다.
- 
<img width="991" height="842" alt="나눔" src="https://github.com/user-attachments/assets/a318b5ee-e01f-40ef-b6b2-e5f9de457b43" />
<img width="960" height="856" alt="나눔명조" src="https://github.com/user-attachments/assets/d3b8ab04-80fb-4166-921f-6efd2cedd86d" />

## 💁 Review Point

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
