### PR TITLE
🎨 Style: ql-picker-label:hover::before #7c32aed 컬러추가

### DIFF
--- a/src/style/base/quill-custom.css
+++ b/src/style/base/quill-custom.css
@@ -602,3 +602,9 @@ div.ql-snow .ql-picker-options .ql-picker-item.ql-selected {
 .ql-picker-label:hover::before {
   color: #7c3aed !important;
 }
+.ql-snow .ql-picker.ql-size .ql-picker-item.ql-selected {
+  color: #7c3aed !important;
+}
+.ql-snow .ql-picker.ql-size .ql-picker-label.ql-active {
+  color: #7c3aed !important;
+}

--- a/src/style/base/quill-custom.css
+++ b/src/style/base/quill-custom.css
@@ -599,3 +599,6 @@ div.ql-snow .ql-picker-options .ql-picker-item.ql-selected {
   height: auto !important;
   max-height: none !important;
 }
+.ql-picker-label:hover::before {
+  color: #7c3aed !important;
+}


### PR DESCRIPTION
<!-- PR 제목은 생성한 이슈와 동일하게 작성해 주세요. ex) ✨ Feat: 로그인 페이지 UI 구현 -->

## 🔗 이슈 번호

<!-- PR과 연관된 이슈 번호를 작성해 주세요. ex) #1 -->
<!-- 이슈가 해결되지 않은 상태로 PR을 업로드한다면 close를 지워주세요. -->

- close #168 

## ✨ 작업한 내용

<!-- 작업한 내용을 작성해 주세요 .-->
- ql-picker-label:hover::before #7c32aed 마우스 포인터를 가져다 대면 파란색이 아닌 보라색으로 표출되게 변경
<img width="724" height="331" alt="마우스 포인터 가져다" src="https://github.com/user-attachments/assets/8e5cac5f-1686-406f-86c3-3d296bc53564" />

## 💁 Review Point

<!-- 코드리뷰가 필요한 부분이 있다면 작성해 주세요. -->

## 💡 참고사항

<!-- 추가로 작성할 내용이 있다면 작성해 주세요. -->
